### PR TITLE
Version 0.0.3

### DIFF
--- a/rage-lint.py
+++ b/rage-lint.py
@@ -9,7 +9,7 @@ from urllib import request
 from colored import fg, attr
 from lxml import etree
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 def silly_log(s):

--- a/rage-lint.py
+++ b/rage-lint.py
@@ -25,6 +25,15 @@ argParser.add_argument('globs', metavar='glob', type=str, nargs='+', help="glob 
 argParser.add_argument('-v', '--verbose', action='count', default=0)
 args = argParser.parse_args()
 
+copyright_str = '\n'.join((
+    '===',
+    '=== %srage-lint%s - RAGE Metafile linter%s' % (fg('red'), fg('yellow'), fg('cyan')),
+    '===     %s[[ %sVersion %s%s%s ]]%s' % (
+        fg('dark_gray'), fg('white'), fg('yellow'), __VERSION__, fg('dark_gray'), fg('cyan')),
+    '===\n',
+))
+print(fg('cyan') + copyright_str + attr(0))
+
 dataDir = dirname(realpath(__file__))
 if getattr(sys, 'frozen', False):
     dataDir = sys._MEIPASS
@@ -35,10 +44,12 @@ if exists(schemaPath):
     schemaAge = time.time() - (os.stat(schemaPath)).st_mtime
     # remove cached after 1 week
     if schemaAge > (3600 * 24 * 7):
+        print("%sRemoving old schema and re-fetching...%s" % (fg('light_gray'), attr(0)))
         os.unlink(schemaPath)
 
 if not exists(schemaPath):
     xsdUrl = "https://raw.githubusercontent.com/GoatG33k/gta5-xsd/master/GTA5.xsd"
+    print("%sDownloading schema...%s" % (fg('cyan'), attr(0)))
     with request.urlopen(xsdUrl) as response, open(schemaPath, 'w') as f:
         f.write(response.read().decode('utf-8'))
         f.close()
@@ -47,6 +58,7 @@ xsdRoot = None
 xsdSchema = None
 
 try:
+    print("%sReading schema...%s" % (fg('yellow'), attr(0)))
     xsdRoot = etree.parse(schemaPath)
     xsdSchema = etree.XMLSchema(xsdRoot)
 except etree.XMLSchemaParseError as e:
@@ -86,18 +98,9 @@ def handle_skip(path, msg):
     print(("  - %s" + msg + "%s") % (fg('yellow'), attr(0)) + "\n", file=sys.stderr)
 
 
-copyright_str = '\n'.join((
-    '===',
-    '=== %srage-lint%s - RAGE Metafile linter%s' % (fg('red'), fg('yellow'), fg('cyan')),
-    '===     %s[[ %sVersion %s%s%s ]]%s' % (
-        fg('dark_gray'), fg('white'), fg('yellow'), __VERSION__, fg('dark_gray'), fg('cyan')),
-    '===\n',
-))
-print(fg('cyan') + copyright_str + attr(0))
-
 print("%sFound %d file%s to lint...%s\n" % (fg('cyan'), len(files), 's' if len(files) > 0 else '', attr(0)))
 for file in files:
-    relative_file_path = realpath(file).replace(os.getcwd(), './')
+    relative_file_path = realpath(file).replace(os.getcwd(), '.')
     print(("Linting %s%s%s" % (fg('yellow'), relative_file_path, attr(0))).ljust(75), end="", file=sys.stderr)
     try:
         doc = etree.parse(file, parser=etree.XMLParser(remove_comments=True))

--- a/rage-lint.py
+++ b/rage-lint.py
@@ -22,6 +22,7 @@ def debug(s):
 
 argParser = argparse.ArgumentParser(description='A linter for RAGE metafiles')
 argParser.add_argument('globs', metavar='glob', type=str, nargs='+', help="glob paths to lint")
+argParser.add_argument('-u', '--update', action='store_true', help='forcibly update to the latest schema')
 argParser.add_argument('-v', '--verbose', action='count', default=0)
 args = argParser.parse_args()
 
@@ -43,13 +44,13 @@ schemaPath = abspath(dataDir + '/schema.xsd')
 if exists(schemaPath):
     schemaAge = time.time() - (os.stat(schemaPath)).st_mtime
     # remove cached after 1 week
-    if schemaAge > (3600 * 24 * 7):
-        print("%sRemoving old schema and re-fetching...%s" % (fg('light_gray'), attr(0)))
+    if schemaAge > (3600 * 24 * 7) or args.update:
+        print("%sRemoving old schema and re-fetching...%s" % (fg('yellow'), attr(0)))
         os.unlink(schemaPath)
 
 if not exists(schemaPath):
     xsdUrl = "https://raw.githubusercontent.com/GoatG33k/gta5-xsd/master/GTA5.xsd"
-    print("%sDownloading schema...%s" % (fg('cyan'), attr(0)))
+    print("%sDownloading schema...%s" % (fg('yellow'), attr(0)))
     with request.urlopen(xsdUrl) as response, open(schemaPath, 'w') as f:
         f.write(response.read().decode('utf-8'))
         f.close()

--- a/rage-lint.py
+++ b/rage-lint.py
@@ -109,6 +109,18 @@ for file in files:
         if rootTagName not in knownRootTypes:
             handle_skip(file, "The root '%s' is not recognized" % rootTagName)
             continue
+        # we do a bit of magic to process R* ambiguous array types:
+        # since <Item> can be anything, if a type is specified in the file,
+        # rewrite the element to be a special element named '__Item__{type}'
+        # which will be a determininstic type
+        for el in doc.iter():
+            if el.tag not in ['Item', 'item']:
+                continue
+            type_attr = el.attrib.get('type')
+            if type_attr is not None and 'xs:' not in type_attr and type_attr != 'NULL' and type_attr in knownRootTypes:
+                new_tag_name = "Item__" + type_attr
+                el.tag = new_tag_name
+
         xsdSchema.assertValid(doc)
         handle_pass()
     except etree.XMLSyntaxError as e:

--- a/rage-lint.version
+++ b/rage-lint.version
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 0, 2, 0),
-    prodvers=(0, 0, 2, 0),
+    filevers=(0, 0, 3, 0),
+    prodvers=(0, 0, 3, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -16,12 +16,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'GoatGeek'),
         StringStruct(u'FileDescription', u'RAGE Metafile Linter'),
-        StringStruct(u'FileVersion', u'0.0.2'),
+        StringStruct(u'FileVersion', u'0.0.3'),
         StringStruct(u'InternalName', u'rage-lint'),
         StringStruct(u'LegalCopyright', u'\xa9 GoatGeek - Licensed under the MIT License'),
         StringStruct(u'OriginalFilename', u'rage-lint.exe'),
         StringStruct(u'ProductName', u'RAGE Metafile Linter'),
-        StringStruct(u'ProductVersion', u'0.0.2')])
+        StringStruct(u'ProductVersion', u'0.0.3')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml==4.6.3
+lxml-stubs==0.2.0
 colored==1.4.2


### PR DESCRIPTION
- Formatting improvements
- Python type stubs
- Added the `-u` / `--update` argument to force re-downloading the schema
- Support for ambiguous types in Rockstar metafiles:
```xml
<ExampleType>
  <Item type="CChildExampleType" />
</ExampleType>
```